### PR TITLE
Touchup: restoring functionality of eval/infer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Create the info file used for training
 To train on painted lidar points.
 ```
   conda activate pp
-  torchrun --nproc_per_node=[gpus] train.py --data_root [path/to/waymo]/kitti_format/  --painted --cam_sync --save-path [checkpoint/path] --max_epoch [num of epochs] --ckpt_freq_epoch [freq]
+  torchrun --nproc_per_node=[gpus] train.py --data_root [path/to/waymo]/kitti_format/  --painted --cam_sync --saved_path [checkpoint/path] --max_epoch [num of epochs] --ckpt_freq_epoch [freq]
 ```
 # Evaluation
 To evaluate the mAP.

--- a/evaluate.py
+++ b/evaluate.py
@@ -346,13 +346,13 @@ def main(args):
                 P0 = calib_info['P0'].astype(np.float32)
                 image_shape = data_dict['batched_img_info'][j]['image_shape']
                 idx = data_dict['batched_img_info'][j]['image_idx']
-                #result_filter = keep_bbox_from_image_range(result, tr_velo_to_cam, r0_rect, P0, image_shape)
-                result_filter = keep_bbox_from_lidar_range(result, pcd_limit_range)
+                result_filter = keep_bbox_from_image_range(result, tr_velo_to_cam, r0_rect, P0, image_shape)
+                result_filter = keep_bbox_from_lidar_range(result_filter, pcd_limit_range)
 
                 lidar_bboxes = result_filter['lidar_bboxes']
                 labels, scores = result_filter['labels'], result_filter['scores']
                 bboxes2d, camera_bboxes = result_filter['bboxes2d'], result_filter['camera_bboxes']
-                for lidar_bbox, label, score, bbox2d, camera_bbox in \
+                for lidar_bboxes, label, score, bbox2d, camera_bbox in \
                     zip(lidar_bboxes, labels, scores, bboxes2d, camera_bboxes):
                     format_result['name'].append(LABEL2CLASSES[label])
                     format_result['truncated'].append(0.0)

--- a/inference.py
+++ b/inference.py
@@ -92,8 +92,8 @@ def main(args):
                 P0 = calib_info['P0'].astype(np.float32)
                 image_shape = data_dict['batched_img_info'][j]['image_shape']
                 idx = data_dict['batched_img_info'][j]['image_idx']
-                #result_filter = keep_bbox_from_image_range(result, tr_velo_to_cam, r0_rect, P0, image_shape)
-                result_filter = keep_bbox_from_lidar_range(result, pcd_limit_range)
+                result_filter = keep_bbox_from_image_range(result, tr_velo_to_cam, r0_rect, P0, image_shape)
+                result_filter = keep_bbox_from_lidar_range(result_filter, pcd_limit_range)
 
                 lidar_bboxes = result_filter['lidar_bboxes']
                 labels, scores = result_filter['labels'], result_filter['scores']


### PR DESCRIPTION
Fixing some recent changes that caused eval/infer to generate 0 accuracy results.
I trained PointPillar with painted inputs from my small samples for 20 epochs, and used it for eval and full inference and they matched well.

```
Evaluating.. Please wait several seconds.
==========BBOX_2D==========
Pedestrian AP@0.5: 21.2244
Cyclist AP@0.5: 0.9649
Car AP@0.7: 18.8221
==========AOS==========
Pedestrian AOS@0.5: 16.4277
Cyclist AOS@0.5: 0.4542
Car AOS@0.7: 12.4721
==========BBOX_BEV==========
Pedestrian AP@0.5: 22.0395
Cyclist AP@0.5: 0.3030
Car AP@0.7: 25.1119
==========BBOX_3D==========
Pedestrian AP@0.5: 15.9730
Cyclist AP@0.5: 0.1299
Car AP@0.7: 14.0517

==========Overall==========
bbox_2d AP: 13.6705
AOS AP: 9.7847
bbox_bev AP: 15.8181
bbox_3d AP: 10.0515
```